### PR TITLE
Fix the format of the transformation when displaying it

### DIFF
--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -6,9 +6,12 @@ import { transform } from "@/utils/openai/transform";
 
 // Define a function to render paragraphs from text
 const renderParagraphs = (text: string): JSX.Element[] => {
-  return text.split('\n').map((paragraph, index) => (
-    <p key={index} className='text-sm text-gray-500'>{paragraph}</p>
-  ));
+  const { text: transformationText } = JSON.parse(text);
+  const parsedTransformation = Array.isArray(transformationText) ? transformationText : transformationText.split('\n');
+
+  return parsedTransformation.map((paragraph: string, index: number) =>
+    paragraph ? <p key={index} className='text-sm text-gray-500'>{paragraph}</p> : <br key={index} />
+  );
 };
 
 export default function Modal({


### PR DESCRIPTION
[TASK: Format transformed outputs and add to the note page](https://www.notion.so/palomagroup/8-Format-transformed-outputs-and-add-to-the-note-page-ff2495dfd1a142d4927a17ddb5cfb7b5)
||BEFORE|AFTER|
|-|-|-|
|EMAIL|<img width="416" alt="Screenshot 2024-02-29 at 3 32 02 PM" src="https://github.com/paloma-group/dictaphone/assets/6463701/258edb0d-03b6-44bb-9cdd-56ec35e04f55">|<img width="511" alt="Screenshot 2024-02-29 at 3 28 51 PM" src="https://github.com/paloma-group/dictaphone/assets/6463701/64c9ea86-c8a2-4434-94ab-2477a409a8e5">|
|TWITTER THREAD|<img width="412" alt="Screenshot 2024-02-29 at 3 32 08 PM" src="https://github.com/paloma-group/dictaphone/assets/6463701/bdd06852-ddd1-4dc5-aedd-3954395af956">|<img width="558" alt="Screenshot 2024-02-29 at 3 29 01 PM" src="https://github.com/paloma-group/dictaphone/assets/6463701/dbab9e62-a5b1-4552-a5ac-8b3d50fc8ebb">|