### PR TITLE
22 - Add edit mode to transcription

### DIFF
--- a/actions/updateTranscript.ts
+++ b/actions/updateTranscript.ts
@@ -1,0 +1,19 @@
+'use server';
+
+import { createServerActionClient } from '@/utils/supabase/server';
+import { revalidatePath } from 'next/cache';
+
+const supabase = createServerActionClient();
+
+export const updateTranscript = async (noteId: number, data: FormData) => {
+  const newTranscript = data.get('transcript');
+
+  const result = await supabase
+    .from('notes')
+    .update({ transcript: newTranscript })
+    .eq('id', noteId);
+
+  revalidatePath(`/recording/${noteId}`);
+
+  return result;
+};

--- a/components/CopyToClipboardButton.tsx
+++ b/components/CopyToClipboardButton.tsx
@@ -4,7 +4,7 @@ import { PiCheck, PiCopy, PiX } from 'react-icons/pi';
 import { Tooltip } from 'react-tooltip';
 
 interface Props {
-  text: string | null;
+  text?: string | null;
 }
 
 type CopyState = 'pending' | 'error' | 'copied';

--- a/components/Note.tsx
+++ b/components/Note.tsx
@@ -1,10 +1,11 @@
 'use client';
 
+import { updateTranscript } from '@/actions/updateTranscript';
 import Modal from '@/components/Modal';
-import Transformation from './Transformation';
 import { formatDate } from '@/utils/date/formatDate';
-import { useState } from 'react';
 import { extractRawTextFromTranscript } from '@/utils/notes/transcript';
+import { useState } from 'react';
+import Transformation from './Transformation';
 
 // Define a function to render highlights from text
 const renderHighlights = (text: string | null): JSX.Element[] => {
@@ -67,6 +68,8 @@ export default function Note({
     setPrompt(promptSelection);
     setModalOpen(true);
   };
+
+  const handleTranscriptionChange = updateTranscript.bind(null, note.id);
 
   if (!note) {
     return <p>No note to display</p>;
@@ -141,6 +144,7 @@ export default function Note({
               title="Transcript"
               created_at={note.created_at}
               text={note.transcript}
+              action={handleTranscriptionChange}
             />
           </div>
         </div>

--- a/components/Transformation.tsx
+++ b/components/Transformation.tsx
@@ -1,27 +1,138 @@
 'use client';
 
+import spinner from '@/assets/spinner.svg';
 import { formatDate } from '@/utils/date/formatDate';
+import Image from 'next/image';
+import { useOptimistic, useState } from 'react';
+import { useFormStatus } from 'react-dom';
+import { PiCheck, PiPencil, PiX } from 'react-icons/pi';
 import { CopyToClipboardButton } from './CopyToClipboardButton';
+
+interface Props {
+  title?: string | null;
+  text?: string | null;
+  created_at?: string | null;
+  action?: (data: FormData) => Promise<void>;
+}
+
+const EditableText = ({
+  isEditing,
+  text,
+}: {
+  isEditing: boolean;
+  text: string;
+}) => {
+  const formState = useFormStatus();
+
+  return (
+    <div className={'w-full relative'}>
+      {isEditing && !formState.pending ? (
+        <>
+          <textarea
+            name={'transcript'}
+            className={'w-full p-2'}
+            defaultValue={text ?? ''}
+            rows={6}
+          />
+          <div className={'absolute right-2 bottom-4 flex gap-4'}></div>
+        </>
+      ) : (
+        <p>{text}</p>
+      )}
+    </div>
+  );
+};
+
+const EditButtons = ({
+  onCancel,
+  isEditing,
+}: {
+  onCancel: () => void;
+  isEditing: boolean;
+}) => {
+  const formState = useFormStatus();
+  console.log(formState);
+  if (!isEditing) {
+    return;
+  }
+
+  if (formState.pending) {
+    return <Image className="m-auto size-4" src={spinner} alt={'Loading'} />;
+  }
+
+  return (
+    <>
+      <button onClick={onCancel} type={'button'}>
+        <PiX className={'text-red-500'} />
+      </button>
+      <button type={'submit'}>
+        <PiCheck className={'text-green-500'} />
+      </button>
+    </>
+  );
+};
 
 export default function Transformation({
   title,
   text,
   created_at,
-}: {
-  title?: string | null;
-  text?: string | null;
-  created_at?: string | null;
-}) {
+  action,
+}: Props) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [optimisticText, updateOptimisticText] = useOptimistic<string>(
+    text ?? ''
+  );
+
+  const handleEditClick = () => {
+    setIsEditing(true);
+  };
+
+  const handleCancelEditing = () => {
+    setIsEditing(false);
+  };
+
+  const handleSave = async () => {
+    setIsEditing(false);
+  };
+
+  const handleAction = async (data: FormData) => {
+    const transcript = data.get('transcript');
+    if (typeof transcript === 'string' && action) {
+      setIsEditing(false);
+      updateOptimisticText(transcript);
+      await action(data);
+    }
+  };
+
   return (
-    <div className="border-t border-white py-6 grid gap-4">
-      <div className={'flex justify-between'}>
-        <h3 className="text-xl font-semibold">{title}</h3>
-        {text && <CopyToClipboardButton text={text} />}
+    <form action={handleAction}>
+      <div className="border-t border-white py-6 grid gap-4">
+        <div className={'flex justify-between'}>
+          <h3 className="text-xl font-semibold">{title}</h3>
+          <div className={'flex gap-4'}>
+            {action && !isEditing && (
+              <button onClick={handleEditClick}>
+                <PiPencil />
+              </button>
+            )}
+            {action && (
+              <EditButtons
+                onCancel={handleCancelEditing}
+                isEditing={isEditing}
+              />
+            )}
+            <CopyToClipboardButton text={optimisticText} />
+          </div>
+        </div>
+        {created_at && (
+          <h4 className="text-sm">{formatDate(new Date(created_at))}</h4>
+        )}
+        {action ? (
+          <EditableText isEditing={isEditing} text={optimisticText} />
+        ) : (
+          <p>{optimisticText}</p>
+        )}
       </div>
-      {created_at && (
-        <h4 className="text-sm">{formatDate(new Date(created_at))}</h4>
-      )}
-      <p>{text}</p>
-    </div>
+    </form>
   );
 }

--- a/components/Transformation.tsx
+++ b/components/Transformation.tsx
@@ -12,7 +12,7 @@ interface Props {
   title?: string | null;
   text?: string | null;
   created_at?: string | null;
-  action?: (data: FormData) => Promise<void>;
+  action?: (data: FormData) => Promise<any>;
 }
 
 const EditableText = ({


### PR DESCRIPTION
Updated the Transformation component to handle updating the text using form actions and `useOptimistic` to make it feel responsive.

Initial:
<img width="529" alt="image" src="https://github.com/paloma-group/dictaphone/assets/4586254/d11b5358-fc26-4b5e-b73d-1f25ae265596">

Editing:
<img width="518" alt="image" src="https://github.com/paloma-group/dictaphone/assets/4586254/a4565560-3452-4c91-bec2-f3bfce881bb6">

Pending:
<img width="530" alt="image" src="https://github.com/paloma-group/dictaphone/assets/4586254/adcc88cb-c1e8-48ea-a243-aeb55e6bd913">
