### PR TITLE
Proof of concept for shortcuts

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,11 +1,8 @@
 import AuthButton from '@/components/AuthButton';
+import { SearchInput } from '@/components/SearchInput';
 import Link from 'next/link';
 
-interface Props {
-  query?: string;
-}
-
-export default function Header({ query = '' }: Props) {
+export default function Header() {
   return (
     <header className="sticky py-8 top-0">
       <div className="container bg-white rounded-full">
@@ -19,13 +16,7 @@ export default function Header({ query = '' }: Props) {
               <span>+</span>
             </Link>
             <form action="/notes" className="grow md:grow-0">
-              <input
-                type="text"
-                name="search"
-                placeholder="Search"
-                className="w-full py-2 px-4 border border-gray-300 rounded-full placeholder:text-black"
-                defaultValue={query}
-              />
+              <SearchInput />
             </form>
           </div>
           <h1 className="text-xl font-semibold italic self-center flex-none px-4">

--- a/components/SearchInput.tsx
+++ b/components/SearchInput.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import React, { useRef } from 'react';
+import { useHotkeys } from 'react-hotkeys-hook';
+
+export const SearchInput = () => {
+  const ref = useRef<HTMLInputElement>(null);
+
+  useHotkeys('meta+k, ctrl+k', () => {
+    if (!ref.current) {
+      return;
+    }
+
+    const selectedText = window.getSelection()?.toString();
+
+    if (selectedText) {
+      ref.current.value = selectedText;
+    }
+
+    ref.current.focus();
+  });
+
+  return (
+    <input
+      ref={ref}
+      type="text"
+      name="search"
+      placeholder="Search"
+      className="w-full py-2 px-4 border border-gray-300 rounded-full placeholder:text-black"
+    />
+  );
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "postcss": "8.4.33",
         "react": "18.2.0",
         "react-dom": "18.2.0",
+        "react-hotkeys-hook": "^4.5.0",
         "react-icons": "^5.0.1",
         "react-tooltip": "^5.26.3",
         "tailwind-merge": "^2.2.1",
@@ -2029,6 +2030,15 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-hotkeys-hook": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/react-hotkeys-hook/-/react-hotkeys-hook-4.5.0.tgz",
+      "integrity": "sha512-Samb85GSgAWFQNvVt3PS90LPPGSf9mkH/r4au81ZP1yOIFayLC3QAvqTgGtJ8YEDMXtPmaVBs6NgipHO6h4Mug==",
+      "peerDependencies": {
+        "react": ">=16.8.1",
+        "react-dom": ">=16.8.1"
       }
     },
     "node_modules/react-icons": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "postcss": "8.4.33",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-hotkeys-hook": "^4.5.0",
     "react-icons": "^5.0.1",
     "react-tooltip": "^5.26.3",
     "tailwind-merge": "^2.2.1",


### PR DESCRIPTION
Added in a hotkeys library to make managing shortcuts much easier.

Initial shortcut is a simple `cmd+k` or `ctrl+k` which will focus the search in the header.
If there is any currently selected text that will be pre-populated into the input.

<img width="491" alt="image" src="https://github.com/paloma-group/dictaphone/assets/4586254/04f48a89-b5e8-4be1-a617-0c3c0c0d2426">

<img width="489" alt="image" src="https://github.com/paloma-group/dictaphone/assets/4586254/a969377b-d1c2-4941-80cd-8c46ef58547e">

This can be expanded out into other shortcuts, but we will need to consider conflicts, i.e. one that was suggested was `cmd+shift+r` but this will conflict with the browser reload shortcut, we could maybe look at using `cmd+shift++` instead.
